### PR TITLE
set KOOS_p = 1 if tags observed at KOOS and not CLC

### DIFF
--- a/R/fixNoFishNodes.R
+++ b/R/fixNoFishNodes.R
@@ -210,6 +210,10 @@ fixNoFishNodes = function(init_file = NULL,
     mod_file[grep('CLC_p ~', mod_file )] = '  CLC_p <- 1 # Single array, no upstream detections'
   }
 
+  if('KOOS' %in% seenSites & ('CLC' %in% unseenSites)){
+    mod_file[grep('KOOS_p ~', mod_file )] = ' KOOS_p <- 1 # Single array, no upstream detections'
+  }
+
   writeLines(mod_file, mod_conn_new)
   close(mod_conn_new)
 


### PR DESCRIPTION
There is no upstream detection after KOOS.  If Clear Creek (CLC) observed 0 tags the detection probability at KOOS should be set to 1.0.  Both sites (CLC and KOOS) cannot be simultaneously set to 1.0 because no transition probability exists in the model.